### PR TITLE
Replace power usage widget with CO2 level widget

### DIFF
--- a/src/dashboards/chaosdorf.haml
+++ b/src/dashboards/chaosdorf.haml
@@ -14,7 +14,7 @@
   .row
     %div{"data-id" => "downlink-traffic", "data-max" => "1000000000", "data-min" => "0", "data-title" => "Downlink Traffic", "data-view" => "Meter", "data-suffix" => "bit/s"}
     %div{"data-id" => "uplink-traffic", "data-max" => "50000000", "data-min" => "0", "data-title" => "Uplink Traffic", "data-view" => "Meter", "data-suffix" => "bit/s"}
-    %div{"data-id" => "power-total", "data-title" => "Power", "data-view" => "Graph", "data-suffix" => "W" }
+    %div{"data-id" => "lounge-co2", "data-title" => "CO2", "data-view" => "Graph", "data-suffix" => "ppm" }
     %div{"data-id" => "music", "data-header" => "now playing", "data-view" => "Music"}
   .row
     %div{"data-id" => "efa", "data-title" => "EFA: Kruppstr.", "data-view" => "Efa"}

--- a/src/jobs/mqtt.rb
+++ b/src/jobs/mqtt.rb
@@ -18,11 +18,10 @@ SCHEDULER.every '5m', :allow_overlapping => false, :first_in => 0 do |job|
     client.connect()
     puts "mqtt: connected to #{client.host} as #{client.client_id}."
     
-    client.subscribe('sensors/flukso/power/sum/30s_average') # power
+    client.subscribe('sensor/esp8266_64760E/data') # hackcenter co2 sensor
     client.subscribe('space/dorfstatus')
     client.subscribe('space/bell') # door bell
     client.subscribe('music/#') # music
-    client.subscribe('sensor/#') # sensorium
 
     client.get do |topic,message|
       message = message.force_encoding('utf-8')

--- a/src/jobs/mqtt.rb
+++ b/src/jobs/mqtt.rb
@@ -68,7 +68,6 @@ SCHEDULER.every '5m', :allow_overlapping => false, :first_in => 0 do |job|
             send_event('music', music_status.clone)
           end
         end
-      end
       elsif topic == 'sensor/esp8266_64760E/data'
         # Hackcenter CO2
         data = JSON.parse(message)

--- a/src/jobs/mqtt.rb
+++ b/src/jobs/mqtt.rb
@@ -20,6 +20,7 @@ SCHEDULER.every '5m', :allow_overlapping => false, :first_in => 0 do |job|
     client.subscribe('space/dorfstatus')
     client.subscribe('space/bell') # door bell
     client.subscribe('music/#') # music
+    client.subscribe('sensor/#') # sensorium
 
     client.get do |topic,message|
       message = message.force_encoding('utf-8')
@@ -65,6 +66,19 @@ SCHEDULER.every '5m', :allow_overlapping => false, :first_in => 0 do |job|
             send_event('music', music_status.clone)
           end
         end
+      end
+      elsif topic == 'sensor/esp8266_64760E/data'
+        # Hackcenter CO2
+        value = Float(topic.co2_ppm)
+        case value
+        when 0...1000
+          status = "normal"
+        when 1000...2000
+          status = "danger"
+        else
+          status = "warning"
+        end
+        send_event('lounge-co2', {text: value, status: status})
       end
     end
     client.disconnect() # TODO: does this make sense?


### PR DESCRIPTION
Subscribes the mqttclient to a new topic (`sensor/#`) and processes messages specifically from `sensor/esp8266_64760E/data`, which is the Hackcenter CO2 Sensor.
Data is collected for 180 steps, which at an update every 20s equates to 1h.

Looks like this in the Dashboard:
![image](https://github.com/chaosdorf/dashpi/assets/24212409/06cd6b74-caf4-4c7d-b4ae-8f2a1c9cc145)


- [x] Remove now unused code relating to power usage
- [x] Adjust danger and warning status thresholds